### PR TITLE
Allow caption-less image posts; add unit tests

### DIFF
--- a/client/post/NewPost.js
+++ b/client/post/NewPost.js
@@ -124,7 +124,7 @@ export default function NewPost (props){
         }
       </CardContent>
       <CardActions>
-        <Button color="primary" variant="contained" disabled={values.text === ''} onClick={clickPost} className={classes.submit}>POST</Button>
+        <Button color="primary" variant="contained" disabled={values.text === '' && !values.photo} onClick={clickPost} className={classes.submit}>POST</Button>
       </CardActions>
     </Card>
   </div>)

--- a/client/post/Post.js
+++ b/client/post/Post.js
@@ -117,9 +117,11 @@ export default function Post (props){
             className={classes.cardHeader}
           />
         <CardContent className={classes.cardContent}>
-          <Typography component="p" className={classes.text}>
-            {props.post.text}
-          </Typography>
+          {props.post.text && (
+            <Typography component="p" className={classes.text}>
+              {props.post.text}
+            </Typography>
+          )}
           {props.post.photo &&
             (<div className={classes.photo}>
               <img

--- a/server/__tests__/post.image.test.js
+++ b/server/__tests__/post.image.test.js
@@ -1,0 +1,87 @@
+/**
+ * Unit/integration tests for caption-less image posts.
+ * Behavior protected: pictures can be posted without a caption.
+ */
+import request from 'supertest'
+import jwt from 'jsonwebtoken'
+import fs from 'fs'
+import path from 'path'
+import app from '../test-app'
+import User from '../models/user.model'
+import Post from '../models/post.model'
+import config from '../../config/config'
+
+// Create a small valid PNG (1x1 pixel) for testing
+const MINI_PNG = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==',
+  'base64'
+)
+
+const createAuthToken = (userId) =>
+  jwt.sign({ _id: userId }, config.jwtSecret)
+
+describe('Caption-less image posts', () => {
+  let testUser
+  let authToken
+
+  beforeEach(async () => {
+    await Post.deleteMany({})
+    await User.deleteMany({ email: 'posttest@example.com' })
+    testUser = new User({
+      name: 'Post Test User',
+      email: 'posttest@example.com',
+      password: 'password123'
+    })
+    testUser._password = '[test]' // satisfy User model validator
+    await testUser.save()
+    authToken = createAuthToken(testUser._id)
+  })
+
+  describe('POST /api/posts/new/:userId', () => {
+    it('creates a post with photo and no caption (text empty)', async () => {
+      const res = await request(app)
+        .post(`/api/posts/new/${testUser._id}`)
+        .set('Authorization', `Bearer ${authToken}`)
+        .field('text', '')
+        .attach('photo', MINI_PNG, 'image.png')
+        .expect(200)
+
+      expect(res.body._id).toBeDefined()
+      expect(res.body.postedBy._id).toBe(testUser._id.toString())
+      expect(res.body.text).toBe('')
+      expect(res.body.photo).toBeDefined()
+    })
+
+    it('creates a post with caption and photo', async () => {
+      const res = await request(app)
+        .post(`/api/posts/new/${testUser._id}`)
+        .set('Authorization', `Bearer ${authToken}`)
+        .field('text', 'My caption')
+        .attach('photo', MINI_PNG, 'image.png')
+        .expect(200)
+
+      expect(res.body.text).toBe('My caption')
+      expect(res.body.photo).toBeDefined()
+    })
+
+    it('rejects post with neither text nor photo', async () => {
+      const res = await request(app)
+        .post(`/api/posts/new/${testUser._id}`)
+        .set('Authorization', `Bearer ${authToken}`)
+        .field('text', '')
+        .expect(400)
+
+      expect(res.body.error).toMatch(/text or a photo/i)
+    })
+
+    it('creates a text-only post (no photo)', async () => {
+      const res = await request(app)
+        .post(`/api/posts/new/${testUser._id}`)
+        .set('Authorization', `Bearer ${authToken}`)
+        .field('text', 'Just text')
+        .expect(200)
+
+      expect(res.body.text).toBe('Just text')
+    })
+  })
+})

--- a/server/helpers/dbErrorHandler.js
+++ b/server/helpers/dbErrorHandler.js
@@ -30,11 +30,12 @@ const getErrorMessage = (err) => {
             default:
                 message = 'Something went wrong'
         }
-    } else {
+    } else if (err.errors) {
         for (let errName in err.errors) {
             if (err.errors[errName].message) message = err.errors[errName].message
         }
     }
+    if (!message && err.message) message = err.message
 
     return message
 }

--- a/server/models/post.model.js
+++ b/server/models/post.model.js
@@ -2,7 +2,7 @@ import mongoose from 'mongoose'
 const PostSchema = new mongoose.Schema({
   text: {
     type: String,
-    required: 'Text is required'
+    default: ''
   },
   photo: {
     data: Buffer,
@@ -18,6 +18,17 @@ const PostSchema = new mongoose.Schema({
   created: {
     type: Date,
     default: Date.now
+  }
+})
+
+// Post must have either text (caption) or photo; caption-less image posts are allowed
+PostSchema.pre('save', function (next) {
+  const hasText = this.text && this.text.trim().length > 0
+  const hasPhoto = this.photo && this.photo.data && this.photo.data.length > 0
+  if (!hasText && !hasPhoto) {
+    next(new Error('Post must have text or a photo'))
+  } else {
+    next()
   }
 })
 

--- a/server/test-app.js
+++ b/server/test-app.js
@@ -4,10 +4,12 @@
 import express from 'express'
 import bodyParser from 'body-parser'
 import userRoutes from './routes/user.routes'
+import postRoutes from './routes/post.routes'
 
 const app = express()
 app.use(bodyParser.json())
 app.use(bodyParser.urlencoded({ extended: true }))
 app.use('/', userRoutes)
+app.use('/', postRoutes)
 
 export default app


### PR DESCRIPTION
**Closes #2 ** 

**Summary of what changed**

    - Post model: text is optional (default ''). A pre-save hook requires the post to have either non-empty text or a photo; otherwise the request is rejected.
    - NewPost component: The POST button is enabled when there is text or a photo (no longer requires both).
    - Post display: Caption is rendered only when props.post.text is present, so photo-only posts show no caption.
    - dbErrorHandler: Uses err.message for plain Error objects.
    - Tests: Added server/__tests__/post.image.test.js with Jest + Supertest.

**How to run the relevant tests**

*MongoDB must be running locally. Tests use the database mernproject_test.
             npm install
             npm test
Or run only the post image tests:
             npx jest server/__tests__/post.image.test.js

**Scenarios & expected behavior**

    - Photo only (no caption) – Post is created and a photo is shown with no caption area.
    - Photo + caption – Post is created and shows both the photo and the caption text.
    - Text only (no photo) – Post is created and shows text as usual.
    - Neither text nor photo – 400 error and message like “text or a photo” required.
    - Empty caption on a photo-only post – No caption block is rendered in the UI.