### PR TITLE
630:P1 User input validation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3170,8 +3170,7 @@
     "commander": {
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "dev": true
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
     },
     "commondir": {
       "version": "1.0.1",
@@ -3492,6 +3491,11 @@
         "@babel/runtime": "^7.8.3",
         "is-in-browser": "^1.0.2"
       }
+    },
+    "cssfilter": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/cssfilter/-/cssfilter-0.0.10.tgz",
+      "integrity": "sha512-FAaLDaplstoRsDR8XGYH51znUN0UY7nMc6Z9/fvE8EXGwvJE9hu7W2vHwx1+bd6gCYnln9nLbzxFTrcO9YQDZw=="
     },
     "cssom": {
       "version": "0.4.4",
@@ -11095,6 +11099,15 @@
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true
+    },
+    "xss": {
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/xss/-/xss-1.0.15.tgz",
+      "integrity": "sha512-FVdlVVC67WOIPvfOwhoMETV72f6GbW7aOabBC3WxN/oUdoEMDyLz4OgRv5/gck2ZeNqEQu+Tb0kloovXOfpYVg==",
+      "requires": {
+        "commander": "^2.20.3",
+        "cssfilter": "0.0.10"
+      }
     },
     "xtend": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -51,8 +51,8 @@
     "body-parser": "1.19.0",
     "compression": "1.7.4",
     "cookie-parser": "1.4.5",
-    "dotenv": "16.3.1",
     "cors": "2.8.5",
+    "dotenv": "16.3.1",
     "express": "4.17.1",
     "express-jwt": "5.3.1",
     "formidable": "1.2.2",
@@ -65,6 +65,7 @@
     "react-dom": "16.13.1",
     "react-hot-loader": "4.12.20",
     "react-router": "5.1.2",
-    "react-router-dom": "5.1.2"
+    "react-router-dom": "5.1.2",
+    "xss": "^1.0.15"
   }
 }

--- a/server/__tests__/user.input.validation.test.js
+++ b/server/__tests__/user.input.validation.test.js
@@ -1,0 +1,162 @@
+/**
+ * Unit tests for user input validation (XSS prevention).
+ * Behavior protected: scripts are not executed; they are stored and displayed as plain text.
+ * Test approach: inserting XSS scripts through API (depicting frontend user input).
+ */
+jest.mock('../helpers/email', () => ({
+  sendVerificationEmail: jest.fn().mockResolvedValue({ success: true })
+}))
+
+import request from 'supertest'
+import jwt from 'jsonwebtoken'
+import app from '../test-app'
+import User from '../models/user.model'
+import Post from '../models/post.model'
+import PendingSignup from '../models/pendingSignup.model'
+import config from '../../config/config'
+
+const MINI_PNG = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==',
+  'base64'
+)
+
+const XSS_SCRIPT = '<script>alert("xss")</script>'
+const XSS_ESCAPED = '&lt;script&gt;alert("xss")&lt;/script&gt;'
+
+const createAuthToken = (userId) =>
+  jwt.sign({ _id: userId }, config.jwtSecret)
+
+describe('User input validation (XSS prevention)', () => {
+  let testUser
+  let authToken
+
+  beforeEach(async () => {
+    await Post.deleteMany({})
+    await PendingSignup.deleteMany({})
+    await User.deleteMany({ email: 'xsstest@example.com' })
+    testUser = new User({
+      name: 'XSS Test User',
+      email: 'xsstest@example.com',
+      password: 'password123'
+    })
+    testUser._password = '[test]'
+    await testUser.save()
+    authToken = createAuthToken(testUser._id)
+  })
+
+  describe('Post text sanitization', () => {
+    it('stores XSS in post text as escaped plain text (not executable)', async () => {
+      const res = await request(app)
+        .post(`/api/posts/new/${testUser._id}`)
+        .set('Authorization', `Bearer ${authToken}`)
+        .field('text', XSS_SCRIPT)
+        .attach('photo', MINI_PNG, 'image.png')
+        .expect(200)
+
+      expect(res.body.text).toBe(XSS_ESCAPED)
+      expect(res.body.text).not.toContain('<script>')
+      expect(res.body.text).not.toContain('</script>')
+    })
+
+    it('allows normal text in posts unchanged', async () => {
+      const normalText = 'Hello, this is safe content!'
+      const res = await request(app)
+        .post(`/api/posts/new/${testUser._id}`)
+        .set('Authorization', `Bearer ${authToken}`)
+        .field('text', normalText)
+        .attach('photo', MINI_PNG, 'image.png')
+        .expect(200)
+
+      expect(res.body.text).toBe(normalText)
+    })
+  })
+
+  describe('Comment text sanitization', () => {
+    let postId
+
+    beforeEach(async () => {
+      const postRes = await request(app)
+        .post(`/api/posts/new/${testUser._id}`)
+        .set('Authorization', `Bearer ${authToken}`)
+        .field('text', 'Post for comment test')
+        .attach('photo', MINI_PNG, 'image.png')
+      postId = postRes.body._id
+    })
+
+    it('stores XSS in comment text as escaped plain text (not executable)', async () => {
+      const res = await request(app)
+        .put('/api/posts/comment')
+        .set('Authorization', `Bearer ${authToken}`)
+        .send({
+          postId,
+          userId: testUser._id,
+          comment: { text: XSS_SCRIPT }
+        })
+        .expect(200)
+
+      const newComment = res.body.comments.find(c => c.text.includes('script') || c.text.includes('alert'))
+      expect(newComment).toBeDefined()
+      expect(newComment.text).toBe(XSS_ESCAPED)
+      expect(newComment.text).not.toContain('<script>')
+    })
+  })
+
+  describe('User profile sanitization', () => {
+    it('stores XSS in user name as escaped when updating profile', async () => {
+      const res = await request(app)
+        .put(`/api/users/${testUser._id}`)
+        .set('Authorization', `Bearer ${authToken}`)
+        .field('name', XSS_SCRIPT)
+        .expect(200)
+
+      expect(res.body.name).toBe(XSS_ESCAPED)
+      expect(res.body.name).not.toContain('<script>')
+    })
+
+    it('stores XSS in user about as escaped when updating profile', async () => {
+      const res = await request(app)
+        .put(`/api/users/${testUser._id}`)
+        .set('Authorization', `Bearer ${authToken}`)
+        .field('name', 'Updated Name')
+        .field('about', XSS_SCRIPT)
+        .expect(200)
+
+      expect(res.body.about).toBe(XSS_ESCAPED)
+      expect(res.body.about).not.toContain('<script>')
+    })
+  })
+
+  describe('Signup name sanitization', () => {
+    it('stores XSS in signup name as escaped (user created after verify)', async () => {
+      const email = 'xss-signup@example.com'
+      await User.deleteMany({ email })
+      await PendingSignup.deleteMany({ email })
+
+      const signupRes = await request(app)
+        .post('/api/users')
+        .send({
+          name: XSS_SCRIPT,
+          email,
+          password: 'password123'
+        })
+        .expect(200)
+
+      const pending = await PendingSignup.findOne({ email })
+      expect(pending).not.toBeNull()
+      expect(pending.name).toBe(XSS_ESCAPED)
+
+      const verifyRes = await request(app)
+        .post('/api/users/verify-email')
+        .send({
+          verificationToken: signupRes.body.verificationToken,
+          code: pending.verificationCode
+        })
+        .expect(200)
+
+      const user = await User.findOne({ email })
+      expect(user).not.toBeNull()
+      expect(user.name).toBe(XSS_ESCAPED)
+      expect(user.name).not.toContain('<script>')
+    })
+  })
+})

--- a/server/controllers/post.controller.js
+++ b/server/controllers/post.controller.js
@@ -1,5 +1,6 @@
 import Post from '../models/post.model'
 import errorHandler from './../helpers/dbErrorHandler'
+import { sanitizeString } from './../helpers/sanitize'
 import formidable from 'formidable'
 import fs from 'fs'
 
@@ -12,6 +13,7 @@ const create = (req, res, next) => {
         error: "Image could not be uploaded"
       })
     }
+    if (fields.text != null) fields.text = sanitizeString(fields.text)
     let post = new Post(fields)
     post.postedBy= req.profile
     if(files.photo){
@@ -118,6 +120,7 @@ const unlike = async (req, res) => {
 
 const comment = async (req, res) => {
   let comment = req.body.comment
+  if (comment && comment.text != null) comment.text = sanitizeString(comment.text)
   comment.postedBy = req.body.userId
   try{
     let result = await Post.findByIdAndUpdate(req.body.postId, {$push: {comments: comment}}, {new: true})

--- a/server/controllers/user.controller.js
+++ b/server/controllers/user.controller.js
@@ -2,6 +2,7 @@ import User from '../models/user.model'
 import PendingSignup from '../models/pendingSignup.model'
 import extend from 'lodash/extend'
 import errorHandler from './../helpers/dbErrorHandler'
+import { sanitizeString } from './../helpers/sanitize'
 import formidable from 'formidable'
 import fs from 'fs'
 import crypto from 'crypto'
@@ -46,7 +47,7 @@ const signupRequest = async (req, res) => {
     await PendingSignup.deleteMany({ email: email.trim().toLowerCase() })
 
     const pending = new PendingSignup({
-      name: name.trim(),
+      name: sanitizeString(name.trim()),
       email: email.trim().toLowerCase(),
       hashed_password,
       salt,
@@ -184,6 +185,8 @@ const update = (req, res) => {
         error: "Photo could not be uploaded"
       })
     }
+    if (fields.name != null) fields.name = sanitizeString(fields.name)
+    if (fields.about != null) fields.about = sanitizeString(fields.about)
     let user = req.profile
     user = extend(user, fields)
     user.updated = Date.now()

--- a/server/helpers/sanitize.js
+++ b/server/helpers/sanitize.js
@@ -1,0 +1,15 @@
+/**
+ * User input sanitization to prevent XSS. Scripts and HTML are escaped
+ * so they are stored and displayed as plain text, not executed.
+ */
+import xss from 'xss'
+
+/**
+ * Sanitize a string so scripts/HTML are escaped and displayed as plain text.
+ * @param {string} input - Raw user input
+ * @returns {string} Sanitized string safe for storage and display
+ */
+export function sanitizeString(input) {
+  if (input == null || typeof input !== 'string') return input
+  return xss(input, { whiteList: {} })
+}


### PR DESCRIPTION
**Closes #4** 

**Summary of what changed**

-   Sanitization helper: Added server/helpers/sanitize.js using the xss package to escape HTML/scripts so they are stored and displayed as plain text.
-   Post text: Sanitize post text before saving.
-   Comment text: Sanitize comment text before adding comments.
-   User profile: Sanitize name and about when updating a user profile.
-   Signup name: Sanitize name during signup.
-   Tests: Added server/__tests__/user.input.validation.test.js with 6 unit tests that send XSS payloads via the API and assert they are stored as escaped plain text.

**How to run the relevant tests**
MongoDB must be running locally. Tests use the database mernproject_test.
  _npm install
  npm test_

Run only the input validation tests:
  _npx jest server/__tests__/user.input.validation.test.js_
  
**Scenarios & expected behavior**

- Post with XSS in text – Value is sanitized before save and displayed as plain text. Scripts are not executed.
- Comment with XSS – Same as above: sanitized and shown as plain text; scripts are not executed.
- User name/about with XSS on profile update – Values are sanitized before saving; profile and menu show plain text only.
- Signup name with XSS – Name is sanitized both in pending signup and in the final user; it appears as plain text everywhere.