### PR TITLE
fix(sonar): JSDoc Promise return for sendVerificationEmail (S4123)

### DIFF
--- a/docs/reviews/PR-12-self-review.md
+++ b/docs/reviews/PR-12-self-review.md
@@ -1,0 +1,9 @@
+# PR-12 self-review
+
+**Issue:** GitHub #12 — `javascript:S4123` at `server/controllers/user.controller.js` line 60 (`await sendVerificationEmail(...)`).
+
+**Cause:** JSDoc on `sendVerificationEmail` said `@returns` a plain object; the function is `async`, so the analyzer treated the awaited value as non-thenable.
+
+**Change:** `server/helpers/email.js` line 36 — `@returns` set to `Promise<{ success: boolean, messageId?: string, previewUrl?: string }>`.
+
+**Outcome:** JSDoc matches runtime; no behavior change; signup tests still pass.

--- a/server/helpers/email.js
+++ b/server/helpers/email.js
@@ -33,7 +33,7 @@ async function getTransporter() {
  * Send verification code to email.
  * @param {string} to - Recipient email
  * @param {string} code - 6-digit verification code
- * @returns {{ success: boolean, messageId?: string, previewUrl?: string }}
+ * @returns {Promise<{ success: boolean, messageId?: string, previewUrl?: string }>}
  */
 export async function sendVerificationEmail(to, code) {
   try {


### PR DESCRIPTION
Closes #12 

# PR-12 self-review

**Issue:** GitHub #12 — `javascript:S4123` at `server/controllers/user.controller.js` line 60 (`await sendVerificationEmail(...)`).

**Cause:** JSDoc on `sendVerificationEmail` said `@returns` a plain object; the function is `async`, so the analyzer treated the awaited value as non-thenable.

**Change:** `server/helpers/email.js` line 36 — `@returns` set to `Promise<{ success: boolean, messageId?: string, previewUrl?: string }>`.

**Outcome:** JSDoc matches runtime; no behavior change; signup tests still pass.
