### PR TITLE
fix(sonar): use Element.remove() for JSS cleanup (S7762)

### DIFF
--- a/client/App.js
+++ b/client/App.js
@@ -9,7 +9,7 @@ const App = () => {
   React.useEffect(() => {
     const jssStyles = document.querySelector('#jss-server-side')
     if (jssStyles) {
-      jssStyles.parentNode.removeChild(jssStyles)
+      jssStyles.remove()
     }
   }, [])
   return (

--- a/docs/reviews/PR-13-self-review.md
+++ b/docs/reviews/PR-13-self-review.md
@@ -1,0 +1,9 @@
+# PR-13 self-review
+
+**Issue:** GitHub #13 — `javascript:S7762` at `client/App.js` line 12 (prefer `childNode.remove()` over `parentNode.removeChild(childNode)`).
+
+**Cause:** Server-side JSS styles were removed with `jssStyles.parentNode.removeChild(jssStyles)`; Sonar flags that pattern in favor of `remove()` on the node itself.
+
+**Change:** `client/App.js` line 12 — replaced with `jssStyles.remove()`.
+
+**Outcome:** Same DOM effect (detach `#jss-server-side` after mount); no intended behavior change.


### PR DESCRIPTION
Close #13 

# PR-13 self-review

**Issue:** GitHub #13 — `javascript:S7762` at `client/App.js` line 12 (prefer `childNode.remove()` over `parentNode.removeChild(childNode)`).

**Cause:** Server-side JSS styles were removed with `jssStyles.parentNode.removeChild(jssStyles)`; Sonar flags that pattern in favor of `remove()` on the node itself.

**Change:** `client/App.js` line 12 — replaced with `jssStyles.remove()`.

**Outcome:** Same DOM effect (detach `#jss-server-side` after mount); no intended behavior change.
