### PR TITLE
fix(sonar): add PropTypes for PrivateRoute component (S6774)

### DIFF
--- a/client/auth/PrivateRoute.js
+++ b/client/auth/PrivateRoute.js
@@ -1,4 +1,5 @@
-import React, { Component } from 'react'
+import React from 'react'
+import PropTypes from 'prop-types'
 import { Route, Redirect } from 'react-router-dom'
 import auth from './auth-helper'
 
@@ -14,5 +15,9 @@ const PrivateRoute = ({ component: Component, ...rest }) => (
     )
   )}/>
 )
+
+PrivateRoute.propTypes = {
+  component: PropTypes.elementType.isRequired
+}
 
 export default PrivateRoute

--- a/docs/reviews/PR-14-self-review.md
+++ b/docs/reviews/PR-14-self-review.md
@@ -1,0 +1,9 @@
+# PR-14 self-review
+
+**Issue:** GitHub #14 — `javascript:S6774` at `client/auth/PrivateRoute.js` line 5 (`component` missing in props validation).
+
+**Cause:** `PrivateRoute` destructures `component` from props but had no `propTypes`, so the `component` prop was unchecked.
+
+**Change:** `client/auth/PrivateRoute.js` — import `prop-types`, set `PrivateRoute.propTypes = { component: PropTypes.elementType.isRequired }`, drop unused `Component` import from `react` (the route target comes from props only).
+
+**Outcome:** Runtime behavior unchanged; invalid `component` types surface as prop-type warnings in development. The issue text about “Last name” / DB does not apply to this Sonar rule or file; this PR only addresses props validation for `PrivateRoute`.


### PR DESCRIPTION
Close #14 

# PR-14 self-review

**Issue:** GitHub #14 — `javascript:S6774` at `client/auth/PrivateRoute.js` line 5 (`component` missing in props validation).

**Cause:** `PrivateRoute` destructures `component` from props but had no `propTypes`, so the `component` prop was unchecked.

**Change:** `client/auth/PrivateRoute.js` — import `prop-types`, set `PrivateRoute.propTypes = { component: PropTypes.elementType.isRequired }`, drop unused `Component` import from `react` (the route target comes from props only).

**Outcome:** Runtime behavior unchanged; invalid `component` types surface as prop-type warnings in development. The issue text about “Last name” / DB does not apply to this Sonar rule or file; this PR only addresses props validation for `PrivateRoute`.
