### PR TITLE
fix(security): validate verify-email input before Mongo query (S5147)

### DIFF
--- a/docs/reviews/PR-15-self-review.md
+++ b/docs/reviews/PR-15-self-review.md
@@ -11,4 +11,6 @@
 
 **Routes:** `server/routes/user.routes.js` and `server/routes/post.routes.js` import the new controllers; `router.param('userId', …)` uses `profileCtrl.userByID`.
 
-**Outcome:** `npm test` — 17/17 passing; intended HTTP behavior unchanged.
+**Sonar S5147 (NoSQL / `verifyEmailAndSignup`):** `parseVerifyEmailInput` in `server/services/user.service.js` ensures `verificationToken` and `code` are plain strings matching expected shapes (64-char hex token, 6-digit code) before `PendingSignup.findOne`; rejects non-strings and malformed input so queries are not built from raw user-controlled objects.
+
+**Outcome:** `npm test` — 17/17 passing; valid signup/verify flow unchanged.

--- a/server/controllers/auth.controller.js
+++ b/server/controllers/auth.controller.js
@@ -10,7 +10,8 @@ import {
   CODE_EXPIRY_MINUTES,
   generateVerificationCode,
   generateVerificationToken,
-  hashPasswordWithSalt
+  hashPasswordWithSalt,
+  parseVerifyEmailInput
 } from '../services/user.service'
 
 const signin = async (req, res) => {
@@ -133,15 +134,19 @@ const signupRequest = async (req, res) => {
  * Verify email with code and complete signup (create user).
  */
 const verifyEmailAndSignup = async (req, res) => {
-  const { verificationToken, code } = req.body || {}
-  if (!verificationToken || !code) {
+  const { verificationToken: rawToken, code: rawCode } = req.body || {}
+  if (rawToken === undefined || rawToken === null || rawCode === undefined || rawCode === null) {
     return res.status(400).json({ error: 'Verification token and code are required.' })
+  }
+  const parsed = parseVerifyEmailInput(rawToken, rawCode)
+  if (!parsed) {
+    return res.status(400).json({ error: 'Invalid or expired code. Please sign up again.' })
   }
 
   try {
     const pending = await PendingSignup.findOne({
-      verificationToken,
-      verificationCode: code.trim()
+      verificationToken: parsed.token,
+      verificationCode: parsed.code
     })
     if (!pending) {
       return res.status(400).json({ error: 'Invalid or expired code. Please sign up again.' })

--- a/server/services/user.service.js
+++ b/server/services/user.service.js
@@ -4,6 +4,24 @@ import User from '../models/user.model'
 export const CODE_EXPIRY_MINUTES = 10
 export const CODE_LENGTH = 6
 
+/**
+ * Safe values for PendingSignup.findOne (strings only; blocks NoSQL operator injection).
+ * Token: 64 hex chars (generateVerificationToken). Code: CODE_LENGTH digits.
+ * @returns {{ token: string, code: string } | null}
+ */
+export function parseVerifyEmailInput(rawToken, rawCode) {
+  if (typeof rawToken !== 'string' || typeof rawCode !== 'string') {
+    return null
+  }
+  const token = rawToken.trim()
+  const code = rawCode.trim()
+  const codeOk = new RegExp(`^\\d{${CODE_LENGTH}}$`).test(code)
+  if (!/^[a-f0-9]{64}$/i.test(token) || !codeOk) {
+    return null
+  }
+  return { token, code }
+}
+
 export function generateVerificationCode() {
   const max = Math.pow(10, CODE_LENGTH)
   const n = parseInt(crypto.randomBytes(4).toString('hex'), 16) % max


### PR DESCRIPTION
Close #21 

# PR-15 self-review

**Issue:** GitHub #15 — “god controller” / low cohesion in `server/controllers/user.controller.js` (mixed auth, profile, follow, people).

**Change:** Split by responsibility; shared helpers in `server/services/user.service.js`:
- `auth.controller.js` — existing signin/signout/JWT middleware plus `signupRequest`, `verifyEmailAndSignup`, `create` (same handlers as before, signup uses `hashPasswordWithSalt` / code+token generators from the service).
- `profile.controller.js` — `userByID` (via `findUserProfileById` in service), `read`, `list`, `update`, `remove`, `photo`, `defaultPhoto`.
- `follow.controller.js` — `addFollowing`, `addFollower`, `removeFollowing`, `removeFollower`.
- `people.controller.js` — `findPeople`.
- Removed `user.controller.js`.

**Routes:** `server/routes/user.routes.js` and `server/routes/post.routes.js` import the new controllers; `router.param('userId', …)` uses `profileCtrl.userByID`.

**Sonar S5147 (NoSQL / `verifyEmailAndSignup`):** `parseVerifyEmailInput` in `server/services/user.service.js` ensures `verificationToken` and `code` are plain strings matching expected shapes (64-char hex token, 6-digit code) before `PendingSignup.findOne`; rejects non-strings and malformed input so queries are not built from raw user-controlled objects.

**Outcome:** `npm test` — 17/17 passing; valid signup/verify flow unchanged.
