### PR TITLE
refactor: extract signupRequest steps into user.service (#16)

### DIFF
--- a/docs/reviews/PR-16-self-review.md
+++ b/docs/reviews/PR-16-self-review.md
@@ -1,0 +1,12 @@
+# PR-16 self-review
+
+**Issue:** GitHub #16 — long method `signupRequest` (validation, duplicate check, hashing, persistence, email).
+
+**Change:** After #15 split, `signupRequest` lives in `server/controllers/auth.controller.js`. Helpers added to `server/services/user.service.js`:
+- `validateSignupRequest(body)` — required fields + trimmed name / normalized email.
+- `ensureEmailNotTaken(emailLower)`.
+- `buildPendingSignup({ name, email, salt, hashed_password })` — codes, token, expiry, `PendingSignup` doc (`sanitizeString` on name).
+- `persistPendingSignup(normalizedEmail, pendingDoc)` — `deleteMany` + `save`.
+- Existing `hashPasswordWithSalt`; `sendVerificationEmail` unchanged in `helpers/email`.
+
+**Outcome:** `npm test` — 17/17 passing; same HTTP behavior as before.

--- a/server/controllers/auth.controller.js
+++ b/server/controllers/auth.controller.js
@@ -4,14 +4,14 @@ import jwt from 'jsonwebtoken'
 import expressJwt from 'express-jwt'
 import config from './../../config/config'
 import errorHandler from './../helpers/dbErrorHandler'
-import { sanitizeString } from './../helpers/sanitize'
 import { sendVerificationEmail } from '../helpers/email'
 import {
-  CODE_EXPIRY_MINUTES,
-  generateVerificationCode,
-  generateVerificationToken,
+  buildPendingSignup,
+  ensureEmailNotTaken,
   hashPasswordWithSalt,
-  parseVerifyEmailInput
+  parseVerifyEmailInput,
+  persistPendingSignup,
+  validateSignupRequest
 } from '../services/user.service'
 
 const signin = async (req, res) => {
@@ -78,40 +78,30 @@ const hasAuthorization = (req, res, next) => {
  * Request signup: create pending signup, send 2FA code to email, return verification token.
  */
 const signupRequest = async (req, res) => {
-  const { name, email, password } = req.body || {}
-  if (!name || !email || !password) {
-    return res.status(400).json({ error: 'Name, email and password are required.' })
+  const validated = validateSignupRequest(req.body)
+  if (!validated.ok) {
+    return res.status(400).json({ error: validated.error })
   }
 
   try {
-    const existing = await User.findOne({ email: email.trim().toLowerCase() })
-    if (existing) {
+    if (!(await ensureEmailNotTaken(validated.email))) {
       return res.status(400).json({ error: 'Email already exists.' })
     }
 
-    const { salt, hashed_password } = hashPasswordWithSalt(password)
-    const verificationCode = generateVerificationCode()
-    const verificationToken = generateVerificationToken()
-    const expiresAt = new Date(Date.now() + CODE_EXPIRY_MINUTES * 60 * 1000)
-
-    await PendingSignup.deleteMany({ email: email.trim().toLowerCase() })
-
-    const pending = new PendingSignup({
-      name: sanitizeString(name.trim()),
-      email: email.trim().toLowerCase(),
-      hashed_password,
+    const { salt, hashed_password } = hashPasswordWithSalt(validated.password)
+    const pending = buildPendingSignup({
+      name: validated.name,
+      email: validated.email,
       salt,
-      verificationCode,
-      verificationToken,
-      expiresAt
+      hashed_password
     })
-    await pending.save()
+    await persistPendingSignup(validated.email, pending)
 
-    const emailResult = await sendVerificationEmail(pending.email, verificationCode)
+    const emailResult = await sendVerificationEmail(pending.email, pending.verificationCode)
     if (!emailResult.success) {
       if (config.env === 'development' && !config.smtpUser) {
         console.log('-----------------------------------------------------------')
-        console.log('DEV: Email could not be sent. Use this verification code:', verificationCode)
+        console.log('DEV: Email could not be sent. Use this verification code:', pending.verificationCode)
         console.log('-----------------------------------------------------------')
       } else {
         await pending.remove()
@@ -121,7 +111,7 @@ const signupRequest = async (req, res) => {
 
     return res.status(200).json({
       message: 'Verification code sent to your email.',
-      verificationToken
+      verificationToken: pending.verificationToken
     })
   } catch (err) {
     console.error('Signup error:', err)

--- a/server/services/user.service.js
+++ b/server/services/user.service.js
@@ -1,8 +1,54 @@
 import crypto from 'crypto'
 import User from '../models/user.model'
+import PendingSignup from '../models/pendingSignup.model'
+import { sanitizeString } from '../helpers/sanitize'
 
 export const CODE_EXPIRY_MINUTES = 10
 export const CODE_LENGTH = 6
+
+/**
+ * @returns {{ ok: true, name: string, email: string, password: string } | { ok: false, error: string }}
+ */
+export function validateSignupRequest(body) {
+  if (!body || typeof body !== 'object') {
+    return { ok: false, error: 'Name, email and password are required.' }
+  }
+  const { name, email, password } = body
+  if (!name || !email || !password) {
+    return { ok: false, error: 'Name, email and password are required.' }
+  }
+  const nameTrim = String(name).trim()
+  const emailTrim = String(email).trim().toLowerCase()
+  if (!nameTrim || !emailTrim) {
+    return { ok: false, error: 'Name, email and password are required.' }
+  }
+  return { ok: true, name: nameTrim, email: emailTrim, password: String(password) }
+}
+
+export async function ensureEmailNotTaken(emailLower) {
+  const existing = await User.findOne({ email: emailLower })
+  return existing === null
+}
+
+export function buildPendingSignup({ name, email, salt, hashed_password }) {
+  const verificationCode = generateVerificationCode()
+  const verificationToken = generateVerificationToken()
+  const expiresAt = new Date(Date.now() + CODE_EXPIRY_MINUTES * 60 * 1000)
+  return new PendingSignup({
+    name: sanitizeString(name),
+    email,
+    hashed_password,
+    salt,
+    verificationCode,
+    verificationToken,
+    expiresAt
+  })
+}
+
+export async function persistPendingSignup(normalizedEmail, pendingDoc) {
+  await PendingSignup.deleteMany({ email: normalizedEmail })
+  await pendingDoc.save()
+}
 
 /**
  * Safe values for PendingSignup.findOne (strings only; blocks NoSQL operator injection).


### PR DESCRIPTION
Close #16 

# PR-16 self-review

**Issue:** GitHub #16 — long method `signupRequest` (validation, duplicate check, hashing, persistence, email).

**Change:** After #15 split, `signupRequest` lives in `server/controllers/auth.controller.js`. Helpers added to `server/services/user.service.js`:
- `validateSignupRequest(body)` — required fields + trimmed name / normalized email.
- `ensureEmailNotTaken(emailLower)`.
- `buildPendingSignup({ name, email, salt, hashed_password })` — codes, token, expiry, `PendingSignup` doc (`sanitizeString` on name).
- `persistPendingSignup(normalizedEmail, pendingDoc)` — `deleteMany` + `save`.
- Existing `hashPasswordWithSalt`; `sendVerificationEmail` unchanged in `helpers/email`.

**Outcome:** `npm test` — 17/17 passing; same HTTP behavior as before.
