### PR TITLE
fix(sonar): use node:crypto import (S7772); jest shim for Node 13

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -6,7 +6,8 @@ module.exports = {
   },
   setupFilesAfterEnv: ['<rootDir>/server/__tests__/setup.js'],
   moduleNameMapper: {
-    '\\.(png|jpg|jpeg|gif|svg)$': '<rootDir>/server/__tests__/__mocks__/fileMock.js'
+    '\\.(png|jpg|jpeg|gif|svg)$': '<rootDir>/server/__tests__/__mocks__/fileMock.js',
+    '^node:crypto$': '<rootDir>/server/__tests__/__mocks__/nodeCrypto.js'
   },
   testTimeout: 30000
 }

--- a/server/__tests__/__mocks__/nodeCrypto.js
+++ b/server/__tests__/__mocks__/nodeCrypto.js
@@ -1,0 +1,1 @@
+module.exports = require('crypto')

--- a/server/auth/password.js
+++ b/server/auth/password.js
@@ -1,5 +1,5 @@
 import bcrypt from 'bcryptjs'
-import crypto from 'crypto'
+import crypto from 'node:crypto'
 
 const BCRYPT_ROUNDS = 10
 

--- a/server/services/user.service.js
+++ b/server/services/user.service.js
@@ -1,4 +1,4 @@
-import crypto from 'crypto'
+import crypto from 'node:crypto'
 import User from '../models/user.model'
 import PendingSignup from '../models/pendingSignup.model'
 import { sanitizeString } from '../helpers/sanitize'


### PR DESCRIPTION
Close #24 
Close #17 

Fixed SonarQube issue from #24 

Prefer `node:crypto` over `crypto`.