### PR TITLE
refactor(client): auth header Strategy (#27)

### DIFF
--- a/client/auth/authStrategy.js
+++ b/client/auth/authStrategy.js
@@ -1,0 +1,33 @@
+const BearerTokenStrategy = {
+  getHeaders(credentials) {
+    const t = credentials && credentials.t
+    if (t == null || String(t) === '') return {}
+    return { Authorization: 'Bearer ' + String(t) }
+  }
+}
+
+const NoAuthStrategy = {
+  getHeaders() {
+    return {}
+  }
+}
+
+let activeStrategy = BearerTokenStrategy
+
+export function setAuthHeaderStrategy(strategy) {
+  activeStrategy = strategy
+}
+
+export function getAuthHeadersFromCredentials(credentials) {
+  return activeStrategy.getHeaders(credentials)
+}
+
+export function getAuthHeaders(token) {
+  return BearerTokenStrategy.getHeaders({ t: token })
+}
+
+export function getAuthHeaderStrategy() {
+  return activeStrategy
+}
+
+export { BearerTokenStrategy, NoAuthStrategy }

--- a/client/post/api-post.js
+++ b/client/post/api-post.js
@@ -1,10 +1,12 @@
+import { getAuthHeadersFromCredentials } from '../auth/authStrategy'
+
 const create = async (params, credentials, post) => {
   try {
     let response = await fetch('/api/posts/new/'+ params.userId, {
       method: 'POST',
       headers: {
         'Accept': 'application/json',
-        'Authorization': 'Bearer ' + credentials.t
+        ...getAuthHeadersFromCredentials(credentials)
       },
       body: post
     })
@@ -21,7 +23,7 @@ const listByUser = async (params, credentials) => {
       headers: {
         'Accept': 'application/json',
         'Content-Type': 'application/json',
-        'Authorization': 'Bearer ' + credentials.t
+        ...getAuthHeadersFromCredentials(credentials)
       }
     })
     return await response.json()
@@ -38,7 +40,7 @@ const listNewsFeed = async (params, credentials, signal) => {
       headers: {
         'Accept': 'application/json',
         'Content-Type': 'application/json',
-        'Authorization': 'Bearer ' + credentials.t
+        ...getAuthHeadersFromCredentials(credentials)
       }
     })    
     return await response.json()
@@ -54,7 +56,7 @@ const remove = async (params, credentials) => {
       headers: {
         'Accept': 'application/json',
         'Content-Type': 'application/json',
-        'Authorization': 'Bearer ' + credentials.t
+        ...getAuthHeadersFromCredentials(credentials)
       }
     })
     return await response.json()
@@ -71,7 +73,7 @@ const like = async (params, credentials, postId) => {
       headers: {
         'Accept': 'application/json',
         'Content-Type': 'application/json',
-        'Authorization': 'Bearer ' + credentials.t
+        ...getAuthHeadersFromCredentials(credentials)
       },
       body: JSON.stringify({userId:params.userId, postId: postId})
     })
@@ -89,7 +91,7 @@ const unlike = async (params, credentials, postId) => {
       headers: {
         'Accept': 'application/json',
         'Content-Type': 'application/json',
-        'Authorization': 'Bearer ' + credentials.t
+        ...getAuthHeadersFromCredentials(credentials)
       },
       body: JSON.stringify({userId:params.userId, postId: postId})
     })
@@ -107,7 +109,7 @@ const comment = async (params, credentials, postId, comment) => {
       headers: {
         'Accept': 'application/json',
         'Content-Type': 'application/json',
-        'Authorization': 'Bearer ' + credentials.t
+        ...getAuthHeadersFromCredentials(credentials)
       },
       body: JSON.stringify({userId:params.userId, postId: postId, comment: comment})
     })
@@ -125,7 +127,7 @@ const uncomment = async (params, credentials, postId, comment) => {
       headers: {
         'Accept': 'application/json',
         'Content-Type': 'application/json',
-        'Authorization': 'Bearer ' + credentials.t
+        ...getAuthHeadersFromCredentials(credentials)
       },
       body: JSON.stringify({userId:params.userId, postId: postId, comment: comment})
     })

--- a/client/user/api-user.js
+++ b/client/user/api-user.js
@@ -1,3 +1,5 @@
+import { getAuthHeadersFromCredentials } from '../auth/authStrategy'
+
 const create = async (user) => {
   try {
     let response = await fetch('/api/users', {
@@ -54,7 +56,7 @@ const read = async (params, credentials, signal) => {
       headers: {
         'Accept': 'application/json',
         'Content-Type': 'application/json',
-        'Authorization': 'Bearer ' + credentials.t
+        ...getAuthHeadersFromCredentials(credentials)
       }
   })
     return await response.json()
@@ -69,7 +71,7 @@ const update = async (params, credentials, user) => {
       method: 'PUT',
       headers: {
         'Accept': 'application/json',
-        'Authorization': 'Bearer ' + credentials.t
+        ...getAuthHeadersFromCredentials(credentials)
       },
       body: user
     })
@@ -86,7 +88,7 @@ const remove = async (params, credentials) => {
       headers: {
         'Accept': 'application/json',
         'Content-Type': 'application/json',
-        'Authorization': 'Bearer ' + credentials.t
+        ...getAuthHeadersFromCredentials(credentials)
       }
     })
     return await response.json()
@@ -102,7 +104,7 @@ const follow = async (params, credentials, followId) => {
       headers: {
         'Accept': 'application/json',
         'Content-Type': 'application/json',
-        'Authorization': 'Bearer ' + credentials.t
+        ...getAuthHeadersFromCredentials(credentials)
       },
       body: JSON.stringify({userId:params.userId, followId: followId})
     })
@@ -119,7 +121,7 @@ const unfollow = async (params, credentials, unfollowId) => {
       headers: {
         'Accept': 'application/json',
         'Content-Type': 'application/json',
-        'Authorization': 'Bearer ' + credentials.t
+        ...getAuthHeadersFromCredentials(credentials)
       },
       body: JSON.stringify({userId:params.userId, unfollowId: unfollowId})
     })
@@ -137,7 +139,7 @@ const findPeople = async (params, credentials, signal) => {
       headers: {
         'Accept': 'application/json',
         'Content-Type': 'application/json',
-        'Authorization': 'Bearer ' + credentials.t
+        ...getAuthHeadersFromCredentials(credentials)
       }
     })    
     return await response.json()

--- a/docs/reviews/PR-27-self-review.md
+++ b/docs/reviews/PR-27-self-review.md
@@ -1,0 +1,11 @@
+# PR-27 self-review — GitHub issue #27
+
+**What was wrong:** The same `Authorization: Bearer …` header was copied in many `fetch` calls in `client/user/api-user.js` and `client/post/api-post.js`.
+
+**What we did:** Added `client/auth/authStrategy.js` with a **Strategy** setup: default `BearerTokenStrategy` builds the header from `credentials.t`, `NoAuthStrategy` adds nothing. `getAuthHeadersFromCredentials` uses whichever strategy is active (`setAuthHeaderStrategy` if you switch later). `getAuthHeaders(token)` wraps the bearer logic for callers that only have a raw token.
+
+**Files:** New `authStrategy.js`; imports and `…getAuthHeadersFromCredentials(credentials)` spreads in both API modules—no manual `Bearer` strings there anymore.
+
+**Behavior:** Same headers as before for signed-in users. No backend changes.
+
+**Checks:** Manual: sign in, load feed, post, like/unlike, follow/unfollow, profile flows. `npm test` if your workflow uses server tests only.


### PR DESCRIPTION
Closes #27 

# PR-27 self-review — GitHub issue #27

**What was wrong:** The same `Authorization: Bearer …` header was copied in many `fetch` calls in `client/user/api-user.js` and `client/post/api-post.js`.

**What we did:** Added `client/auth/authStrategy.js` with a **Strategy** setup: default `BearerTokenStrategy` builds the header from `credentials.t`, `NoAuthStrategy` adds nothing. `getAuthHeadersFromCredentials` uses whichever strategy is active (`setAuthHeaderStrategy` if you switch later). `getAuthHeaders(token)` wraps the bearer logic for callers that only have a raw token.

**Files:** New `authStrategy.js`; imports and `…getAuthHeadersFromCredentials(credentials)` spreads in both API modules—no manual `Bearer` strings there anymore.

**Behavior:** Same headers as before for signed-in users. No backend changes.

**Checks:** Manual: sign in, load feed, post, like/unlike, follow/unfollow, profile flows. `npm test` if your workflow uses server tests only.
