### PR TITLE
P3/630p3 reinventing the wheel in ad hoc request logging replace with adapter issue#30

### DIFF
--- a/docs/reviews/PR-30-self-review.md
+++ b/docs/reviews/PR-30-self-review.md
@@ -1,0 +1,11 @@
+# PR-30 self-review — GitHub issue #30
+
+**Issue:** Ad-hoc request logging in `server/express.js` used `console.log` directly instead of a single shared logging entry point.
+
+**What we did:** Introduced an **Adapter** at `server/helpers/logger.js`: `info()` delegates to `console.log`, `error()` to `console.error`. Request timing middleware calls `logger.info` with the same message shape as before (`[ISO timestamp] METHOD path statusCode durationms`). The generic Express error handler logs through `logger.error(err)` instead of `console.log(err)`.
+
+**Files:** New `server/helpers/logger.js`; `server/express.js` imports the module and replaces direct console use in those two spots.
+
+**Non-goals (per issue):** No external logging services; no broad replacement of `console.*` elsewhere (`server.js`, controllers, email helper left unchanged).
+
+**Checks:** Start the server and hit a route; log line should still show method, path, status, and duration. `npm test` — 17/17 passing.

--- a/server/express.js
+++ b/server/express.js
@@ -6,6 +6,7 @@ import compress from 'compression'
 import cors from 'cors'
 import helmet from 'helmet'
 import Template from './../template'
+import * as logger from './helpers/logger'
 import userRoutes from './routes/user.routes'
 import authRoutes from './routes/auth.routes'
 import postRoutes from './routes/post.routes'
@@ -44,7 +45,7 @@ app.use((req, res, next) => {
   const start = Date.now()
   res.on('finish', () => {
     const duration = Date.now() - start
-    console.log(`[${new Date().toISOString()}] ${req.method} ${req.originalUrl} ${res.statusCode} ${duration}ms`)
+    logger.info(`[${new Date().toISOString()}] ${req.method} ${req.originalUrl} ${res.statusCode} ${duration}ms`)
   })
   next()
 })
@@ -85,7 +86,7 @@ app.use((err, req, res, next) => {
     res.status(401).json({"error" : err.name + ": " + err.message})
   }else if (err) {
     res.status(400).json({"error" : err.name + ": " + err.message})
-    console.log(err)
+    logger.error(err)
   }
 })
 

--- a/server/helpers/logger.js
+++ b/server/helpers/logger.js
@@ -1,0 +1,11 @@
+/**
+ * Logger adapter: routes log output through one module so server code does not
+ * depend on console directly (Adapter pattern for observability).
+ */
+export function info(...args) {
+  console.log(...args)
+}
+
+export function error(...args) {
+  console.error(...args)
+}


### PR DESCRIPTION
Closes #30 

# PR-30 self-review — GitHub issue #30

**Issue:** Ad-hoc request logging in `server/express.js` used `console.log` directly instead of a single shared logging entry point.

**What we did:** Introduced an **Adapter** at `server/helpers/logger.js`: `info()` delegates to `console.log`, `error()` to `console.error`. Request timing middleware calls `logger.info` with the same message shape as before (`[ISO timestamp] METHOD path statusCode durationms`). The generic Express error handler logs through `logger.error(err)` instead of `console.log(err)`.

**Files:** New `server/helpers/logger.js`; `server/express.js` imports the module and replaces direct console use in those two spots.

**Non-goals (per issue):** No external logging services; no broad replacement of `console.*` elsewhere (`server.js`, controllers, email helper left unchanged).

**Checks:** Start the server and hit a route; log line should still show method, path, status, and duration. `npm test` — 17/17 passing.
