### PR TITLE
AuthContext and useAuth for Newsfeed, Post, Profile (#31)

### DIFF
--- a/client/App.js
+++ b/client/App.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import MainRouter from './MainRouter'
+import { AuthProvider } from './auth/AuthContext'
 import {BrowserRouter} from 'react-router-dom'
 import { ThemeProvider } from '@material-ui/styles'
 import theme from './theme'
@@ -15,7 +16,9 @@ const App = () => {
   return (
   <BrowserRouter>
       <ThemeProvider theme={theme}>
-        <MainRouter/>
+        <AuthProvider>
+          <MainRouter/>
+        </AuthProvider>
       </ThemeProvider>
   </BrowserRouter>
 )}

--- a/client/auth/AuthContext.js
+++ b/client/auth/AuthContext.js
@@ -1,0 +1,43 @@
+import React, { createContext, useContext, useEffect, useState } from 'react'
+import auth, { AUTH_STATE_CHANGE_EVENT } from './auth-helper'
+
+const AuthContextMissing = Symbol('AuthContextMissing')
+
+const AuthContext = createContext(AuthContextMissing)
+
+function readSession() {
+  return auth.isAuthenticated()
+}
+
+/**
+ * Holds the current JWT session (or false) and refreshes when sessionStorage changes
+ * (Observer-style updates via auth-helper notifications).
+ */
+export function AuthProvider({ children }) {
+  const [session, setSession] = useState(() => readSession())
+
+  useEffect(() => {
+    const sync = () => setSession(readSession())
+    if (typeof window !== 'undefined') {
+      window.addEventListener(AUTH_STATE_CHANGE_EVENT, sync)
+      return () => window.removeEventListener(AUTH_STATE_CHANGE_EVENT, sync)
+    }
+  }, [])
+
+  return (
+    <AuthContext.Provider value={session}>
+      {children}
+    </AuthContext.Provider>
+  )
+}
+
+/**
+ * Same value shape as auth.isAuthenticated(): false, or { user, token } from session.
+ */
+export function useAuth() {
+  const session = useContext(AuthContext)
+  if (session === AuthContextMissing) {
+    throw new Error('useAuth must be used within an AuthProvider')
+  }
+  return session
+}

--- a/client/auth/auth-helper.js
+++ b/client/auth/auth-helper.js
@@ -1,5 +1,14 @@
 import { signout } from './api-auth.js'
 
+/** Browser event so auth subscribers (e.g. AuthProvider) can refresh after session changes. */
+export const AUTH_STATE_CHANGE_EVENT = 'mern-social-auth-change'
+
+function emitAuthStateChange() {
+  if (typeof window !== 'undefined') {
+    window.dispatchEvent(new CustomEvent(AUTH_STATE_CHANGE_EVENT))
+  }
+}
+
 const auth = {
   isAuthenticated() {
     if (typeof window == "undefined")
@@ -13,11 +22,13 @@ const auth = {
   authenticate(jwt, cb) {
     if (typeof window !== "undefined")
       sessionStorage.setItem('jwt', JSON.stringify(jwt))
+    emitAuthStateChange()
     cb()
   },
   clearJWT(cb) {
     if (typeof window !== "undefined")
       sessionStorage.removeItem('jwt')
+    emitAuthStateChange()
     cb()
     //optional
     signout().then((data) => {

--- a/client/post/Newsfeed.js
+++ b/client/post/Newsfeed.js
@@ -3,7 +3,7 @@ import {makeStyles} from '@material-ui/core/styles'
 import Card from '@material-ui/core/Card'
 import Typography from '@material-ui/core/Typography'
 import Divider from '@material-ui/core/Divider'
-import auth from './../auth/auth-helper'
+import { useAuth } from './../auth/AuthContext'
 import PostList from './PostList'
 import {listNewsFeed} from './api-post.js'
 import NewPost from './NewPost'
@@ -26,7 +26,7 @@ const useStyles = makeStyles(theme => ({
 export default function Newsfeed () {
   const classes = useStyles()
   const [posts, setPosts] = useState([])
-  const jwt = auth.isAuthenticated()
+  const jwt = useAuth()
 
   useEffect(() => {
     const abortController = new AbortController()

--- a/client/post/Post.js
+++ b/client/post/Post.js
@@ -1,5 +1,5 @@
 import React, {useState, useEffect} from 'react'
-import auth from './../auth/auth-helper'
+import { useAuth } from './../auth/AuthContext'
 import Card from '@material-ui/core/Card'
 import CardHeader from '@material-ui/core/CardHeader'
 import CardContent from '@material-ui/core/CardContent'
@@ -51,7 +51,7 @@ const useStyles = makeStyles(theme => ({
 
 export default function Post (props){
   const classes = useStyles()
-  const jwt = auth.isAuthenticated()
+  const jwt = useAuth()
   const checkLike = (likes) => {
     let match = likes.indexOf(jwt.user._id) !== -1
     return match
@@ -107,7 +107,7 @@ export default function Post (props){
             avatar={
               <Avatar src={'/api/users/photo/'+props.post.postedBy._id}/>
             }
-            action={props.post.postedBy._id === auth.isAuthenticated().user._id &&
+            action={props.post.postedBy._id === jwt.user._id &&
               <IconButton onClick={deletePost}>
                 <DeleteIcon />
               </IconButton>

--- a/client/user/Profile.js
+++ b/client/user/Profile.js
@@ -12,7 +12,7 @@ import Typography from '@material-ui/core/Typography'
 import Edit from '@material-ui/icons/Edit'
 import Divider from '@material-ui/core/Divider'
 import DeleteUser from './DeleteUser'
-import auth from './../auth/auth-helper'
+import { useAuth } from './../auth/AuthContext'
 import {read} from './api-user.js'
 import {Redirect, Link} from 'react-router-dom'
 import FollowProfileButton from './../user/FollowProfileButton'
@@ -46,7 +46,7 @@ export default function Profile({ match }) {
     following: false
   })
   const [posts, setPosts] = useState([])
-  const jwt = auth.isAuthenticated()
+  const jwt = useAuth()
 
   useEffect(() => {
     const abortController = new AbortController()
@@ -125,7 +125,7 @@ export default function Profile({ match }) {
               <Avatar src={photoUrl} className={classes.bigAvatar}/>
             </ListItemAvatar>
             <ListItemText primary={values.user.name} secondary={values.user.email}/> {
-             auth.isAuthenticated().user && auth.isAuthenticated().user._id == values.user._id
+             jwt.user && jwt.user._id == values.user._id
              ? (<ListItemSecondaryAction>
                   <Link to={"/user/edit/" + values.user._id}>
                     <IconButton aria-label="Edit" color="primary">

--- a/docs/reviews/PR-31-self-review.md
+++ b/docs/reviews/PR-31-self-review.md
@@ -1,0 +1,11 @@
+# PR-31 self-review — GitHub issue #31
+
+**Issue:** Several UI screens called `auth.isAuthenticated()` from `auth-helper` directly, spreading auth coupling and making session changes hard to observe from React.
+
+**What we did:** Added **Observer-style** updates: `client/auth/AuthContext.js` exports `AuthProvider` and `useAuth()`. The provider keeps the current session (same shape as `auth.isAuthenticated()`—`false` or `{ user, token }`) in React state and listens for a small browser event emitted when `authenticate` / `clearJWT` run in `auth-helper.js`, so subscribers re-render after sign-in or sign-out without redesigning routing or `Menu`.
+
+**Files:** New `AuthContext.js`; `App.js` wraps `MainRouter` with `AuthProvider`; `auth-helper.js` dispatches `AUTH_STATE_CHANGE_EVENT` after session writes; `Newsfeed.js`, `Post.js`, and `Profile.js` use `useAuth()` only (no direct `auth.isAuthenticated()` in those three).
+
+**Non-goals (per issue):** `Menu`, `PrivateRoute`, `Home`, and other components still use `auth-helper` as before; no new authorization features.
+
+**Checks:** Manual: signed-out redirects and restrictions unchanged; signed-in user can use newsfeed, like/delete posts, profile follow/edit affordances as before. `npm test` — 17/17 passing.


### PR DESCRIPTION
Closes #31 

# PR-31 self-review — GitHub issue #31

**Issue:** Several UI screens called `auth.isAuthenticated()` from `auth-helper` directly, spreading auth coupling and making session changes hard to observe from React.

**What we did:** Added **Observer-style** updates: `client/auth/AuthContext.js` exports `AuthProvider` and `useAuth()`. The provider keeps the current session (same shape as `auth.isAuthenticated()`—`false` or `{ user, token }`) in React state and listens for a small browser event emitted when `authenticate` / `clearJWT` run in `auth-helper.js`, so subscribers re-render after sign-in or sign-out without redesigning routing or `Menu`.

**Files:** New `AuthContext.js`; `App.js` wraps `MainRouter` with `AuthProvider`; `auth-helper.js` dispatches `AUTH_STATE_CHANGE_EVENT` after session writes; `Newsfeed.js`, `Post.js`, and `Profile.js` use `useAuth()` only (no direct `auth.isAuthenticated()` in those three).

**Non-goals (per issue):** `Menu`, `PrivateRoute`, `Home`, and other components still use `auth-helper` as before; no new authorization features.

**Checks:** Manual: signed-out redirects and restrictions unchanged; signed-in user can use newsfeed, like/delete posts, profile follow/edit affordances as before. `npm test` — 17/17 passing.
