### PR TITLE
PostList mediator context for Newsfeed and Profile (#33)

### DIFF
--- a/client/post/Newsfeed.js
+++ b/client/post/Newsfeed.js
@@ -7,6 +7,7 @@ import { useAuth } from './../auth/AuthContext'
 import PostList from './PostList'
 import {listNewsFeed} from './api-post.js'
 import NewPost from './NewPost'
+import { PostListProvider, usePostList } from './PostListContext'
 
 const useStyles = makeStyles(theme => ({
   card: {
@@ -23,9 +24,10 @@ const useStyles = makeStyles(theme => ({
     minHeight: 330
   }
 }))
-export default function Newsfeed () {
+
+function NewsfeedWithList () {
   const classes = useStyles()
-  const [posts, setPosts] = useState([])
+  const { posts, setPosts, addPost, removePost } = usePostList()
   const jwt = useAuth()
 
   useEffect(() => {
@@ -49,28 +51,23 @@ export default function Newsfeed () {
 
   }, [])
 
-  const addPost = (post) => {
-    const updatedPosts = [...posts]
-    updatedPosts.unshift(post)
-    setPosts(updatedPosts)
-  }
-  const removePost = (post) => {
-    const updatedPosts = [...posts]
-    const index = updatedPosts.indexOf(post)
-    updatedPosts.splice(index, 1)
-    setPosts(updatedPosts)
-  }
-
-    return (
-      <Card className={classes.card}>
-        <Typography type="title" className={classes.title}>
-          Newsfeed
-        </Typography>
-        <Divider/>
-        <NewPost addUpdate={addPost}/>
-        <Divider/>
-        <PostList removeUpdate={removePost} posts={posts}/>
-      </Card>
-    )
+  return (
+    <Card className={classes.card}>
+      <Typography type="title" className={classes.title}>
+        Newsfeed
+      </Typography>
+      <Divider/>
+      <NewPost addUpdate={addPost}/>
+      <Divider/>
+      <PostList removeUpdate={(post) => removePost(post._id)} posts={posts}/>
+    </Card>
+  )
 }
 
+export default function Newsfeed () {
+  return (
+    <PostListProvider>
+      <NewsfeedWithList />
+    </PostListProvider>
+  )
+}

--- a/client/post/PostListContext.js
+++ b/client/post/PostListContext.js
@@ -1,0 +1,44 @@
+import React, { createContext, useCallback, useContext, useMemo, useState } from 'react'
+
+const PostListContextMissing = Symbol('PostListContextMissing')
+
+const PostListContext = createContext(PostListContextMissing)
+
+/**
+ * Mediator for post-list state: add/remove/replace rules live in one place so
+ * screens stay thin (e.g. dedupe-by-id could be added here only).
+ */
+export function PostListProvider({ children }) {
+  const [posts, setPostsState] = useState([])
+
+  const setPosts = useCallback((next) => {
+    setPostsState(Array.isArray(next) ? next : [])
+  }, [])
+
+  const addPost = useCallback((post) => {
+    setPostsState((prev) => [post, ...prev])
+  }, [])
+
+  const removePost = useCallback((postId) => {
+    setPostsState((prev) => prev.filter((p) => p._id !== postId))
+  }, [])
+
+  const value = useMemo(
+    () => ({ posts, setPosts, addPost, removePost }),
+    [posts, setPosts, addPost, removePost]
+  )
+
+  return (
+    <PostListContext.Provider value={value}>
+      {children}
+    </PostListContext.Provider>
+  )
+}
+
+export function usePostList() {
+  const ctx = useContext(PostListContext)
+  if (ctx === PostListContextMissing) {
+    throw new Error('usePostList must be used within PostListProvider')
+  }
+  return ctx
+}

--- a/client/user/Profile.js
+++ b/client/user/Profile.js
@@ -18,6 +18,7 @@ import {Redirect, Link} from 'react-router-dom'
 import FollowProfileButton from './../user/FollowProfileButton'
 import ProfileTabs from './../user/ProfileTabs'
 import {listByUser} from './../post/api-post.js'
+import { PostListProvider, usePostList } from './../post/PostListContext'
 
 const useStyles = makeStyles(theme => ({
   root: theme.mixins.gutters({
@@ -38,14 +39,14 @@ const useStyles = makeStyles(theme => ({
   }
 }))
 
-export default function Profile({ match }) {
+function ProfileWithList ({ match }) {
   const classes = useStyles()
   const [values, setValues] = useState({
     user: {following:[], followers:[]},
     redirectToSignin: false,
     following: false
   })
-  const [posts, setPosts] = useState([])
+  const { posts, setPosts, removePost } = usePostList()
   const jwt = useAuth()
 
   useEffect(() => {
@@ -70,10 +71,10 @@ export default function Profile({ match }) {
   }, [match.params.userId])
   
   const checkFollow = (user) => {
-    const match = user.followers.some((follower)=> {
+    const matchFollower = user.followers.some((follower)=> {
       return follower._id == jwt.user._id
     })
-    return match
+    return matchFollower
   }
   const clickFollowButton = (callApi) => {
     callApi({
@@ -100,12 +101,6 @@ export default function Profile({ match }) {
         setPosts(data)
       }
     })
-  }
-  const removePost = (post) => {
-    const updatedPosts = posts
-    const index = updatedPosts.indexOf(post)
-    updatedPosts.splice(index, 1)
-    setPosts(updatedPosts)
   }
 
     const photoUrl = values.user._id
@@ -143,9 +138,15 @@ export default function Profile({ match }) {
               new Date(values.user.created)).toDateString()}/>
           </ListItem>
         </List>
-        <ProfileTabs user={values.user} posts={posts} removePostUpdate={removePost}/>
+        <ProfileTabs user={values.user} posts={posts} removePostUpdate={(post) => removePost(post._id)}/>
       </Paper>
     )
 }
 
-
+export default function Profile (props) {
+  return (
+    <PostListProvider>
+      <ProfileWithList {...props} />
+    </PostListProvider>
+  )
+}

--- a/docs/reviews/PR-33-self-review.md
+++ b/docs/reviews/PR-33-self-review.md
@@ -1,0 +1,11 @@
+# PR-33 self-review — GitHub issue #33
+
+**Issue:** `Newsfeed` and `Profile` both implemented their own post-array add/remove logic (`unshift`, `indexOf`/`splice`), duplicating list coordination and risking inconsistent behavior.
+
+**What we did:** Added a **Mediator** as `client/post/PostListContext.js`: `PostListProvider` holds list state and exposes `setPosts`, `addPost`, and `removePost(postId)`. List updates are implemented once (immutable prepend for add, filter-by-id for remove). Each screen wraps its tree in its own `PostListProvider` instance so feeds stay independent; consumers use `usePostList()` and pass `(post) => removePost(post._id)` into `PostList` where a post object is still expected.
+
+**Files:** New `PostListContext.js`; `Newsfeed.js` splits default export (provider wrapper + inner list UI); `Profile.js` same pattern with `ProfileWithList`.
+
+**Non-goals (per issue):** No backend or UI redesign; behavior matches prior flows (new post at top of feed, delete removes item from feed/profile list).
+
+**Checks:** Manual: create post on feed, delete from feed/profile, profile tab list updates. `npm test` — 17/17 passing.


### PR DESCRIPTION
Closes #33 

# PR-33 self-review — GitHub issue #33

**Issue:** `Newsfeed` and `Profile` both implemented their own post-array add/remove logic (`unshift`, `indexOf`/`splice`), duplicating list coordination and risking inconsistent behavior.

**What we did:** Added a **Mediator** as `client/post/PostListContext.js`: `PostListProvider` holds list state and exposes `setPosts`, `addPost`, and `removePost(postId)`. List updates are implemented once (immutable prepend for add, filter-by-id for remove). Each screen wraps its tree in its own `PostListProvider` instance so feeds stay independent; consumers use `usePostList()` and pass `(post) => removePost(post._id)` into `PostList` where a post object is still expected.

**Files:** New `PostListContext.js`; `Newsfeed.js` splits default export (provider wrapper + inner list UI); `Profile.js` same pattern with `ProfileWithList`.

**Non-goals (per issue):** No backend or UI redesign; behavior matches prior flows (new post at top of feed, delete removes item from feed/profile list).

**Checks:** Manual: create post on feed, delete from feed/profile, profile tab list updates. `npm test` — 17/17 passing.
